### PR TITLE
Change colour of results from blue to green

### DIFF
--- a/file-search/result_panel.py
+++ b/file-search/result_panel.py
@@ -224,7 +224,7 @@ class ResultPanel:
 
         if addTruncationMarker:
             linetext += "</span><span size=\"smaller\"><i> [...]</i>"
-        line = "<b>%d:</b> <span foreground=\"blue\">%s</span>" % (lineno, linetext)
+        line = "<b>%d:</b> <span foreground=\"green\">%s</span>" % (lineno, linetext)
         newIt = self.treeStore.append(it, None)
         self.treeStore.set(newIt, 0, line, 2, lineno)
 


### PR DESCRIPTION
The default blue colour looks great in lighter GTK themes, but is almost impossible to view in darker-coloured GTK themes.
By changing the result colour from blue to green, we have the result text visible in both light and dark GTK themes.